### PR TITLE
Escape environment variable reference when writing to .profile.d/

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -7,5 +7,5 @@ ENV_DIR=${3:-}
 
 echo "------> Generating .profile.d file to generate google-credentials.json at startup"
 mkdir -p $BUILD_DIR/.profile.d
-echo "echo ${GOOGLE_CREDENTIALS@Q} > /app/google-credentials.json" > $BUILD_DIR/.profile.d/google-credentials.sh
+echo "echo \${GOOGLE_CREDENTIALS} > /app/google-credentials.json" > $BUILD_DIR/.profile.d/google-credentials.sh
 chmod +x $BUILD_DIR/.profile.d/google-credentials.sh


### PR DESCRIPTION
https://github.com/elishaterada/heroku-google-application-credentials-buildpack/tree/2a92505ab601da64a8802cde3871b671c5178fca